### PR TITLE
GoLang : Array returning null handling

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -72,7 +72,8 @@ class AstCreator(
     val methodReturn = methodReturnNode(rootNode, Defines.anyTypeName)
     val declsAsts = rootNode
       .json(ParserKeys.Decls)
-      .arrOpt.getOrElse(ArrayBuffer.empty)
+      .arrOpt
+      .getOrElse(ArrayBuffer.empty)
       .flatMap { item =>
         val node = createParserNodeInfo(item)
         astForNode(node, true)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -12,6 +12,7 @@ import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
 import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 import ujson.Value
 
 import scala.collection.mutable

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -12,10 +12,10 @@ import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.BatchedUpdate.DiffGraphBuilder
 import ujson.Value
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 class AstCreator(
   val relPathFileName: String,
@@ -72,7 +72,7 @@ class AstCreator(
     val methodReturn = methodReturnNode(rootNode, Defines.anyTypeName)
     val declsAsts = rootNode
       .json(ParserKeys.Decls)
-      .arr
+      .arrOpt.getOrElse(ArrayBuffer.empty)
       .flatMap { item =>
         val node = createParserNodeInfo(item)
         astForNode(node, true)


### PR DESCRIPTION
Above fix is for the following error log trace
```
ujson.Value$InvalidData: Expected ujson.Arr (data: null)
	at ujson.Value$InvalidData$.apply(Value.scala:202) ~[com.lihaoyi.ujson_3-3.3.0.jar:3.3.0]
	at ujson.Value.arr(Value.scala:51) ~[com.lihaoyi.ujson_3-3.3.0.jar:3.3.0]
	at ujson.Value.arr$(Value.scala:9) ~[com.lihaoyi.ujson_3-3.3.0.jar:3.3.0]
	at ujson.Null$.arr(Value.scala:259) ~[com.lihaoyi.ujson_3-3.3.0.jar:3.3.0]
	at io.joern.gosrc2cpg.astcreation.AstCreator.astForTranslationUnit(AstCreator.scala:74) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at io.joern.gosrc2cpg.astcreation.AstCreator.createAst(AstCreator.scala:50) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at io.joern.gosrc2cpg.passes.AstCreationPass.$anonfun$1$$anonfun$1(AstCreationPass.scala:27) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at scala.util.Try$.apply(Try.scala:210) ~[org.scala-lang.scala-library-2.13.12.jar:?]
	at io.joern.gosrc2cpg.passes.AstCreationPass.$anonfun$1(AstCreationPass.scala:29) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at io.joern.x2cpg.utils.TimeUtils$.time(TimeUtils.scala:15) ~[io.joern.x2cpg_3-0.1.4.jar:0.1.4]
	at io.joern.gosrc2cpg.passes.AstCreationPass.runOnPart(AstCreationPass.scala:37) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at io.joern.gosrc2cpg.passes.AstCreationPass.runOnPart(AstCreationPass.scala:22) ~[io.joern.gosrc2cpg_3-0.1.4.jar:0.1.4]
	at io.shiftleft.passes.ConcurrentWriterCpgPass.createApplySerializeAndStore$$anonfun$1(ParallelCpgPass.scala:91) ~[io.shiftleft.codepropertygraph_3-0.1.5.jar:0.1.5]
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687) ~[org.scala-lang.scala-library-2.13.12.jar:?]
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467) ~[org.scala-lang.scala-library-2.13.12.jar:?]
	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?]


```