### PR TITLE
fix for exclusion rule before ast creation

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -5,18 +5,15 @@ import com.typesafe.config.ConfigFactory
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.preprocessing.EjsPreprocessor
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.Environment
-import io.joern.x2cpg.utils.ExternalCommand
+import io.joern.x2cpg.utils.{Environment, ExternalCommand}
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
 import java.nio.file.Paths
 import java.util.regex.Pattern
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
-import scala.util.Try
 
 object AstGenRunner {
 
@@ -441,7 +438,7 @@ class AstGenRunner(config: Config) {
   def execute(out: File): AstGenRunnerResult = {
     val tmpInput = filterAndCopyFiles()
     val in       = File(config.inputPath)
-    runAstGenNative(in, out) match {
+    runAstGenNative(tmpInput, out) match {
       case Success(result) =>
         val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out), tmpInput)
         val skipped = skippedFiles(result.toList)


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This PR streamlines the AST generation process by consolidating import statements and fixing a bug in the file exclusion mechanism. It replaces configuration input with a filtered temporary file to ensure proper application of exclusion rules, while also merging redundant imports from utility and Scala packages.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>